### PR TITLE
Add unit tests for core store utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "scripts": {
         "dev": "vite",
         "build": "vite build",
-        "preview": "vite preview"
+        "preview": "vite preview",
+        "test": "npx tsc src/lib/*.ts --outDir build --module ES2020 --target ES2020 --moduleResolution node --skipLibCheck && node --test tests/*.js"
     },
     "dependencies": {
         "lit": "^3.3.1"

--- a/tests/persist.test.js
+++ b/tests/persist.test.js
@@ -1,0 +1,84 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createStore } from '../build/store.js'
+import { persist, localStorageAdapter } from '../build/persist.js'
+
+const flush = () => new Promise(res => setTimeout(res, 0))
+
+describe('persist', () => {
+    it('rehydrates state and calls onRehydrate', async () => {
+        let stored = JSON.stringify({ v: 1, s: { a: 1 } })
+        const adapter = {
+            getItem: async () => stored,
+            setItem: async () => {}
+        }
+        const store = createStore({ a: 0 })
+        let rehydrated
+        await persist(store, { key: 'k', adapter, onRehydrate: s => (rehydrated = s) })
+        assert.deepEqual(store.getState(), { a: 1 })
+        assert.deepEqual(rehydrated, { a: 1 })
+    })
+
+    it('migrates when version differs', async () => {
+        let stored = JSON.stringify({ v: 0, s: { a: '1' } })
+        const adapter = {
+            getItem: async () => stored,
+            setItem: async () => {}
+        }
+        const store = createStore({ a: 0 })
+        await persist(store, { key: 'm', adapter, version: 1, migrate: s => ({ a: Number(s.a) }) })
+        assert.deepEqual(store.getState(), { a: 1 })
+    })
+
+    it('saves partialized state on change', async () => {
+        let saved
+        const adapter = {
+            getItem: async () => null,
+            setItem: async (k, v) => {
+                saved = v
+            }
+        }
+        const store = createStore({ a: 0, b: 0 })
+        await persist(store, { key: 'p', adapter, partialize: s => ({ a: s.a }) })
+        store.setState({ a: 2 })
+        await flush()
+        assert.equal(saved, JSON.stringify({ v: 1, s: { a: 2 } }))
+    })
+})
+
+describe('localStorageAdapter', () => {
+    it('wraps global localStorage', () => {
+        const data = {}
+        globalThis.localStorage = {
+            getItem: k => (k in data ? data[k] : null),
+            setItem: (k, v) => {
+                data[k] = v
+            },
+            removeItem: k => {
+                delete data[k]
+            }
+        }
+        localStorageAdapter.setItem('a', '1')
+        assert.equal(localStorageAdapter.getItem('a'), '1')
+        localStorageAdapter.removeItem('a')
+        assert.equal(localStorageAdapter.getItem('a'), null)
+    })
+
+    it('handles localStorage errors gracefully', () => {
+        globalThis.localStorage = {
+            getItem: () => {
+                throw new Error('fail')
+            },
+            setItem: () => {
+                throw new Error('fail')
+            },
+            removeItem: () => {
+                throw new Error('fail')
+            }
+        }
+        assert.equal(localStorageAdapter.getItem('a'), null)
+        assert.doesNotThrow(() => localStorageAdapter.setItem('a', '1'))
+        assert.doesNotThrow(() => localStorageAdapter.removeItem('a'))
+    })
+})
+

--- a/tests/store-controller.test.js
+++ b/tests/store-controller.test.js
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createStore, shallow } from '../build/store.js'
+import { StoreController } from '../build/store-controller.js'
+
+const flush = () => new Promise(res => setTimeout(res, 0))
+
+class Host {
+    constructor() {
+        this.controllers = []
+        this.updateCount = 0
+    }
+    addController(c) {
+        this.controllers.push(c)
+    }
+    requestUpdate() {
+        this.updateCount++
+    }
+}
+
+describe('StoreController', () => {
+    it('subscribes to single selector and updates host', async () => {
+        const store = createStore({ a: 0 })
+        const host = new Host()
+        const controller = new StoreController(host, store, s => s.a)
+        assert.equal(controller.value, 0)
+        controller.hostConnected()
+        store.setState({ a: 1 })
+        await flush()
+        assert.equal(host.updateCount, 1)
+        controller.hostDisconnected()
+        store.setState({ a: 2 })
+        await flush()
+        assert.equal(host.updateCount, 1)
+        assert.equal(host.controllers.length, 1)
+    })
+
+    it('supports struct selectors with per-field equality', async () => {
+        const store = createStore({ a: 0, obj: { x: 1 } })
+        const host = new Host()
+        const controller = new StoreController(host, store, { a: s => s.a, obj: s => s.obj }, { obj: shallow })
+        controller.hostConnected()
+        store.setState({ a: 1 })
+        await flush()
+        assert.equal(host.updateCount, 1)
+        store.setState({ obj: { x: 1 } })
+        await flush()
+        assert.equal(host.updateCount, 1) // shallow equal -> no update
+        store.setState({ obj: { x: 2 } })
+        await flush()
+        assert.equal(host.updateCount, 2)
+        assert.deepEqual(controller.value, { a: 1, obj: { x: 2 } })
+    })
+})
+

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -1,0 +1,91 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createStore, shallow } from '../build/store.js'
+
+const flush = () => new Promise(res => setTimeout(res, 0))
+
+describe('shallow', () => {
+    it('returns true for same reference', () => {
+        const obj = { a: 1 }
+        assert.equal(shallow(obj, obj), true)
+    })
+
+    it('returns true for shallow equal objects', () => {
+        assert.equal(shallow({ a: 1, b: 2 }, { a: 1, b: 2 }), true)
+    })
+
+    it('returns false for different structures', () => {
+        assert.equal(shallow({ a: 1 }, { a: 2 }), false)
+        assert.equal(shallow({ a: 1 }, { a: 1, b: 2 }), false)
+    })
+
+    it('returns false when either argument is not an object', () => {
+        assert.equal(shallow(null, {}), false)
+    })
+})
+
+describe('createStore', () => {
+    it('gets and sets state', async () => {
+        const store = createStore({ count: 0 })
+        assert.deepEqual(store.getState(), { count: 0 })
+        const calls = []
+        const unsub = store.subscribe(s => s.count)((next, prev) => calls.push([next, prev]))
+        store.setState({ count: 1 })
+        await flush()
+        assert.deepEqual(store.getState(), { count: 1 })
+        assert.deepEqual(calls, [[0, 0], [1, 0]])
+        unsub()
+    })
+
+    it('supports functional updater', async () => {
+        const store = createStore({ n: 1 })
+        store.setState(s => ({ n: s.n + 1 }))
+        await flush()
+        assert.deepEqual(store.getState(), { n: 2 })
+    })
+
+    it('batches notifications within a microtask', async () => {
+        const store = createStore({ a: 0 })
+        let calls = 0
+        store.subscribe(s => s.a)(() => calls++)
+        store.setState({ a: 1 })
+        store.setState({ a: 2 })
+        await flush()
+        assert.equal(calls, 2) // initial + one batched update
+    })
+
+    it('allows custom equality in subscribe', async () => {
+        const store = createStore({ obj: { x: 1 } })
+        let calls = 0
+        store.subscribe(s => s.obj, shallow)(() => calls++)
+        store.setState({ obj: { x: 1 } })
+        await flush()
+        assert.equal(calls, 1) // only initial call
+    })
+
+    it('subscribeAll receives state changes', async () => {
+        const store = createStore({ a: 0 })
+        const events = []
+        store.subscribeAll((s, prev) => events.push([s.a, prev.a]))
+        store.setState({ a: 1 })
+        await flush()
+        assert.deepEqual(events, [[0, 0], [1, 0]])
+    })
+
+    it('destroy removes all subscribers', async () => {
+        const store = createStore({ a: 0 })
+        let calls = 0
+        store.subscribe(s => s.a)(() => calls++)
+        store.destroy()
+        store.setState({ a: 1 })
+        await flush()
+        assert.equal(calls, 1) // initial call only
+    })
+
+    it('__rehydrate replaces state', () => {
+        const store = createStore({ a: 1 })
+        store.__rehydrate?.({ a: 5 })
+        assert.deepEqual(store.getState(), { a: 5 })
+    })
+})
+


### PR DESCRIPTION
## Summary
- add comprehensive unit tests for store functions, controllers, and persistence layer
- configure `npm test` to build TypeScript sources and run the tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0d9bbc58832e9171a524dd9dbffb