### PR TITLE
Add todos and theme examples

### DIFF
--- a/src/examples/theme/bootstrap.ts
+++ b/src/examples/theme/bootstrap.ts
@@ -1,0 +1,8 @@
+import { persist, localStorageAdapter } from '../../lib/persist'
+import { themeStore } from './state'
+
+await persist(themeStore, {
+    key: 'theme',
+    adapter: localStorageAdapter,
+    version: 1
+})

--- a/src/examples/theme/components/toggle.ts
+++ b/src/examples/theme/components/toggle.ts
@@ -1,0 +1,19 @@
+import { LitElement, html, css } from 'lit'
+import { customElement } from 'lit/decorators.js'
+import { StoreController } from '../../../lib/store-controller'
+import { actions, themeStore } from '../state'
+
+@customElement('theme-toggle')
+export class ThemeToggle extends LitElement {
+    static styles = css`
+        button {
+            padding: 0.5rem 0.75rem;
+        }
+    `
+
+    theme = new StoreController(this, themeStore, s => s.theme)
+
+    render() {
+        return html`<button @click=${actions.toggle}>Theme: ${this.theme.value}</button>`
+    }
+}

--- a/src/examples/theme/index.html
+++ b/src/examples/theme/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="./index.ts" type="module"></script>
+    <script src="./bootstrap.ts" type="module"></script>
+    <title>Theme Example</title>
+  </head>
+  <body>
+    <theme-app></theme-app>
+  </body>
+</html>

--- a/src/examples/theme/index.ts
+++ b/src/examples/theme/index.ts
@@ -1,0 +1,10 @@
+import { LitElement, html } from 'lit'
+import { customElement } from 'lit/decorators.js'
+import './components/toggle'
+
+@customElement('theme-app')
+export class ThemeApp extends LitElement {
+    render() {
+        return html`<theme-toggle></theme-toggle>`
+    }
+}

--- a/src/examples/theme/state.ts
+++ b/src/examples/theme/state.ts
@@ -1,0 +1,13 @@
+import { createStore } from '../../lib/store'
+
+export type ThemeState = { theme: 'light' | 'dark' }
+export const themeStore = createStore<ThemeState>({ theme: 'light' })
+
+export const actions = {
+    toggle() {
+        themeStore.setState(
+            s => ({ theme: s.theme === 'light' ? 'dark' : 'light' }),
+            'theme/toggle'
+        )
+    }
+}

--- a/src/examples/todos/bootstrap.ts
+++ b/src/examples/todos/bootstrap.ts
@@ -1,0 +1,11 @@
+import { persist, localStorageAdapter } from '../../lib/persist'
+import { withDevtools } from '../../devtools/redux'
+import { todosStore } from './state'
+
+withDevtools(todosStore, 'todos')
+
+await persist(todosStore, {
+    key: 'todos',
+    adapter: localStorageAdapter,
+    version: 1
+})

--- a/src/examples/todos/components/counter.ts
+++ b/src/examples/todos/components/counter.ts
@@ -1,0 +1,17 @@
+import { LitElement, html } from 'lit'
+import { customElement } from 'lit/decorators.js'
+import { todosStore } from '../state'
+import { StoreController } from '../../../lib/store-controller'
+
+@customElement('todo-counter')
+export class TodoCounter extends LitElement {
+    stats = new StoreController(this, todosStore, {
+        total: s => s.todos.length,
+        remaining: s => s.todos.filter(t => !t.done).length
+    })
+
+    render() {
+        const { total, remaining } = this.stats.value
+        return html`<div>${remaining} / ${total} remaining</div>`
+    }
+}

--- a/src/examples/todos/components/input.ts
+++ b/src/examples/todos/components/input.ts
@@ -1,0 +1,38 @@
+import { LitElement, html, css } from 'lit'
+import { customElement } from 'lit/decorators.js'
+import { actions } from '../state'
+
+@customElement('todo-input')
+export class TodoInput extends LitElement {
+    static styles = css`
+        input {
+            padding: 0.5rem;
+        }
+        button {
+            margin-left: 0.5rem;
+            padding: 0.5rem 0.75rem;
+        }
+    `
+
+    private value = ''
+
+    render() {
+        return html`
+            <input
+                .value=${this.value}
+                @input=${(e: InputEvent) => (this.value = (e.target as HTMLInputElement).value)}
+                placeholder="Add todo"
+            />
+            <button @click=${this.add}>Add</button>
+        `
+    }
+
+    private add() {
+        const text = this.value.trim()
+        if (text) {
+            actions.add(text)
+            this.value = ''
+            this.requestUpdate()
+        }
+    }
+}

--- a/src/examples/todos/components/list.ts
+++ b/src/examples/todos/components/list.ts
@@ -1,0 +1,35 @@
+import { LitElement, html, css } from 'lit'
+import { customElement } from 'lit/decorators.js'
+import { todosStore, actions } from '../state'
+import { StoreController } from '../../../lib/store-controller'
+
+@customElement('todo-list')
+export class TodoList extends LitElement {
+    static styles = css`
+        li {
+            list-style: none;
+        }
+        li.done {
+            text-decoration: line-through;
+        }
+        button {
+            margin-left: 0.5rem;
+        }
+    `
+
+    todos = new StoreController(this, todosStore, s => s.todos)
+
+    render() {
+        return html`
+            <ul>
+                ${this.todos.value.map(
+                    t => html`<li class=${t.done ? 'done' : ''}>
+                        <input type="checkbox" .checked=${t.done} @change=${() => actions.toggle(t.id)} />
+                        ${t.text}
+                        <button @click=${() => actions.remove(t.id)}>x</button>
+                    </li>`
+                )}
+            </ul>
+        `
+    }
+}

--- a/src/examples/todos/index.html
+++ b/src/examples/todos/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="./index.ts" type="module"></script>
+    <script src="./bootstrap.ts" type="module"></script>
+    <title>Todos Example</title>
+  </head>
+  <body>
+    <todo-app></todo-app>
+  </body>
+</html>

--- a/src/examples/todos/index.ts
+++ b/src/examples/todos/index.ts
@@ -1,0 +1,16 @@
+import { LitElement, html } from 'lit'
+import { customElement } from 'lit/decorators.js'
+import './components/input'
+import './components/list'
+import './components/counter'
+
+@customElement('todo-app')
+export class TodoApp extends LitElement {
+    render() {
+        return html`
+            <todo-counter></todo-counter>
+            <todo-input></todo-input>
+            <todo-list></todo-list>
+        `
+    }
+}

--- a/src/examples/todos/state.ts
+++ b/src/examples/todos/state.ts
@@ -1,0 +1,22 @@
+import { createStore } from '../../lib/store'
+
+export type Todo = { id: number; text: string; done: boolean }
+export interface TodosState { todos: Todo[] }
+
+export const todosStore = createStore<TodosState>({ todos: [] })
+
+export const actions = {
+    add(text: string) {
+        const todo: Todo = { id: Date.now(), text, done: false }
+        todosStore.setState(s => ({ todos: [...s.todos, todo] }), 'todos/add')
+    },
+    toggle(id: number) {
+        todosStore.setState(
+            s => ({ todos: s.todos.map(t => (t.id === id ? { ...t, done: !t.done } : t)) }),
+            'todos/toggle'
+        )
+    },
+    remove(id: number) {
+        todosStore.setState(s => ({ todos: s.todos.filter(t => t.id !== id) }), 'todos/remove')
+    }
+}


### PR DESCRIPTION
## Summary
- Add todos example with add/toggle/remove actions, selector-based counter, and persistence with devtools
- Add theme toggle example with persisted theme state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac12c475e8832e95853fcfaa0c72f4