### PR TITLE
docs: add example readmes

### DIFF
--- a/src/examples/counter/README.md
+++ b/src/examples/counter/README.md
@@ -1,0 +1,11 @@
+# Counter Example
+
+Demonstrates a simple counter built with **lit-store**.
+
+## Key features
+- `createStore` holds the counter state with an initial `count` of 0.
+- Actions update state via `setState` for increment, decrement and reset.
+- `StoreController` subscribes the viewer component to the `count` slice so only it re-renders.
+- Other components dispatch actions without subscribing to updates, remaining static.
+- Integrated with Redux DevTools using `withDevtools` for easy debugging.
+- State is persisted across page reloads via `persist` and the `localStorageAdapter`.

--- a/src/examples/theme/README.md
+++ b/src/examples/theme/README.md
@@ -1,0 +1,9 @@
+# Theme Example
+
+A minimal app that toggles between light and dark themes using **lit-store**.
+
+## Key features
+- `createStore` tracks the current theme value.
+- An action flips the theme using a functional `setState` call.
+- `StoreController` keeps the `theme-toggle` component in sync with store changes.
+- User choice is saved with `persist` and `localStorageAdapter` so the theme survives reloads.

--- a/src/examples/todos/README.md
+++ b/src/examples/todos/README.md
@@ -1,0 +1,11 @@
+# Todos Example
+
+A small todo list demonstrating more advanced **lit-store** usage.
+
+## Key features
+- `createStore` manages an array of todo items.
+- Actions add, toggle and remove todos through immutable `setState` updates.
+- Components subscribe to state with `StoreController` for reactive lists and inputs.
+- Derived selectors compute todo statistics (total and remaining) in the `todo-counter` component.
+- Connected to Redux DevTools via `withDevtools` for inspection.
+- State persistence with `persist` and `localStorageAdapter` retains todos between sessions.


### PR DESCRIPTION
## Summary
- document counter example and its store features
- describe theme example and persistence
- explain todos example with derived selectors, devtools, and persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac15d919b8832eb9528b18ab0d2f1e