### PR TITLE
docs: add beginner-friendly documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# lit-store Documentation
+
+Welcome! These pages explain how to use **lit-store** to manage state in Lit applications. Each guide is written in plain language so you can follow along even if you're new to state management.
+
+## Table of Contents
+- [Installation](./installation.md)
+- [Getting Started](./getting-started.md)
+- [State Persistence](./persistence.md)
+- [Redux DevTools](./devtools.md)
+
+If you're unsure where to start, read the Getting Started guide.

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -1,0 +1,11 @@
+# Redux DevTools
+
+lit-store can integrate with the Redux DevTools browser extension so you can inspect changes over time.
+
+```ts
+import { withDevtools } from 'lit-store/devtools/redux'
+
+withDevtools(store, 'counter')
+```
+
+The second argument is a name that appears in the DevTools panel. State changes from the store will show up as actions, making debugging easier.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,47 @@
+# Getting Started
+
+This guide shows the basics of creating and using a store.
+
+## 1. Create a store
+
+```ts
+import { createStore } from 'lit-store/lib/store'
+
+const store = createStore({ count: 0 })
+```
+
+`createStore` takes an initial state object. The store holds the state and lets you update it later.
+
+## 2. Connect the store to a Lit element
+
+```ts
+import { html, LitElement } from 'lit'
+import { StoreController } from 'lit-store/lib/store-controller'
+
+class CounterElement extends LitElement {
+  private count = new StoreController(this, store, s => s.count)
+
+  render() {
+    return html`
+      <button @click=
+        ${() => store.setState({ count: this.count.value + 1 })}>
+        Count: ${this.count.value}
+      </button>
+    `
+  }
+}
+```
+
+`StoreController` keeps the element in sync with the store. When state changes the element updates automatically.
+
+## 3. Subscribe to part of the state
+
+You can subscribe to only the bits of state you care about by passing a selector function to `StoreController` or `store.select`.
+
+```ts
+store.select(s => s.count).subscribe(value => {
+  console.log('count changed to', value)
+})
+```
+
+Selectors help avoid unnecessary updates and make your components faster.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,9 @@
+# Installation
+
+lit-store is published on npm. You can add it to your project with a single command.
+
+```bash
+npm install lit-store
+```
+
+The package has a peer dependency on [Lit](https://lit.dev/). Make sure your project has Lit installed as well.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,11 @@
+# State Persistence
+
+Sometimes you want your state to survive a page refresh. The `persist` helper saves and restores the store using a storage adapter.
+
+```ts
+import { persist, localStorageAdapter } from 'lit-store/lib/persist'
+
+persist(store, { key: 'counter', adapter: localStorageAdapter })
+```
+
+The example above saves the state under the `counter` key in `localStorage`. You can build your own adapter if you need a different storage backend.


### PR DESCRIPTION
## Summary
- create docs/ directory with beginner-friendly guides
- add dedicated pages for installation, getting started, state persistence and Redux DevTools

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac177492bc832e8f51540c7e4a218e